### PR TITLE
set post/comment author from current user

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,6 +4,7 @@ class CommentsController < ApplicationController
   def create
     @post = Post.find(params[:post_id])
     @comment = @post.comments.create(comment_params)
+    @comment.author = current_user.name
     redirect_to post_path(@post)
   end
  

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,6 +11,7 @@ class PostsController < ApplicationController
 
   def create
     @post = Post.new(post_params)
+    @post.author = current_user.name
     if @post.save
     	redirect_to @post
   	else
@@ -28,7 +29,7 @@ class PostsController < ApplicationController
 
     def update 
     @post = Post.find(params[:id])
-
+    @post.author = current_user.name
       if @post.update(post_params)
         redirect_to @post
       else

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,9 +1,5 @@
 <%= form_for([@post, @post.comments.build]) do |f| %>
   <p>
-    <%= f.label :author %><br>
-    <%= f.text_field :author %>
-  </p>
-  <p>
     <%= f.label :body %><br>
     <%= f.text_area :body %>
   </p>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,12 +3,6 @@
     <%= f.label :title %><br>
     <%= f.text_field :title %>
   </p>
- 
-  <p>
-    <%= f.label :author %><br>
-    <%= f.text_field :author %>
-  </p>
-
   <p>
     <%= f.label :body %><br>
     <%= f.text_area :body %>


### PR DESCRIPTION
- remove author field from comment and post forms. 
- change create and update methods of post and comments
  to pull in current_user.name as author.
